### PR TITLE
fix: Parallelize on both axes

### DIFF
--- a/oars/.gitignore
+++ b/oars/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.vim/

--- a/oars/Cargo.toml
+++ b/oars/Cargo.toml
@@ -13,8 +13,8 @@ license = "MIT"
 rand = "0.8"
 primes = "0.3"
 itertools = "0.10"
-num = "0.3"
-ndarray = "0.14.0"
+num = "0.4"
+ndarray = "0.15.4"
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 rayon = { version = "1.3", optional = true }

--- a/oars/src/constructors/bose.rs
+++ b/oars/src/constructors/bose.rs
@@ -130,7 +130,7 @@ impl<T: Integer> ParOAConstructor<T> for Bose<T> {
             .enumerate()
             .for_each(|(col_idx, mut col)| {
                 col.axis_iter_mut(Axis(0))
-                    .into_iter()
+                    .into_par_iter()
                     .enumerate()
                     .for_each(|(row_idx, mut row)| match col_idx {
                         0 => row[[row_idx; 0]] = T::from(row_idx).unwrap() / self.prime_base,
@@ -147,7 +147,7 @@ impl<T: Integer> ParOAConstructor<T> for Bose<T> {
             .enumerate()
             .for_each(|(col_idx, mut col)| {
                 col.axis_iter_mut(Axis(0))
-                    .into_iter()
+                    .into_par_iter()
                     .enumerate()
                     .for_each(|(row_idx, mut row)| {
                         row[[row_idx; 0]] = (initial_points[[row_idx, 0]]

--- a/oars/src/constructors/bush.rs
+++ b/oars/src/constructors/bush.rs
@@ -135,7 +135,7 @@ impl<T: Integer> ParOAConstructor<T> for Bush<T> {
                 let coeffs =
                     to_base_fixed(T::from(row_idx).unwrap(), self.prime_base, self.strength);
                 row.axis_iter_mut(Axis(0))
-                    .into_iter()
+                    .into_par_iter()
                     .enumerate()
                     .for_each(|(col_idx, mut col)| {
                         col[[col_idx; 0]] =
@@ -155,7 +155,7 @@ impl<T: Integer> ParOAConstructor<T> for Bush<T> {
                 .enumerate()
                 .for_each(|(row_idx, mut row)| {
                     row.axis_iter_mut(Axis(0))
-                        .into_iter()
+                        .into_par_iter()
                         .enumerate()
                         .for_each(|(_, mut col)| {
                             col[[0 as usize; 0]] = T::from(row_idx - 1).unwrap() % self.prime_base;


### PR DESCRIPTION
This parallelizes on both axes rather than using a parallel iterator arbitrarily on one axis, which should generalize better for larger orthogonal arrays.